### PR TITLE
Add `import pynsca` to Usage

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,6 +4,7 @@ NSCA.
 Usage
 =====
 
+ >>> import pynsca
  >>> from pynsca import NSCANotifier
  >>> notif = NSCANotifier("nagios")
  >>> notif.svc_result("host", "service", pynsca.OK, "Looks Good!")


### PR DESCRIPTION
Added `import pynsca` to the usage instructions.

This is needed for the `pynsca.OK` to work.

(Possibly move constants to their own class?).
