### PR TITLE
Close socket and sendall data

### DIFF
--- a/pynsca.py
+++ b/pynsca.py
@@ -170,4 +170,5 @@ class NSCANotifier(object):
                 self.encryption_mode, self.password)
 
         # and send it
-        sk.send(toserver_pkt)
+        sk.sendall(toserver_pkt)
+        sk.close()


### PR DESCRIPTION
Hi,

I've added sk.close(), to close properly the socket at the end and I've replaced send() by sendall() to be sure that everything has been sent, as explained in Python documentation: https://docs.python.org/2/library/socket.html#socket.socket.sendall

Thanks for the merge.

Regards.
