### PR TITLE
Special characters don't go through

### DIFF
--- a/pynsca.py
+++ b/pynsca.py
@@ -107,7 +107,7 @@ class NSCANotifier(object):
                 return_code,
                 self._force_str(host_name),
                 self._force_str(svc_description),
-                self._force_str(plugin_output),
+                self._force_str(self._escape_newlines(plugin_output)),
         ]
 
         # calculate crc32 and insert into the list
@@ -121,6 +121,10 @@ class NSCANotifier(object):
         toserver_pkt = self._encrypt_packet(toserver_pkt, iv, mode, password)
 
         return toserver_pkt
+
+    def _escape_newlines(self, text):
+        """Escape backslash and newlines; see https://github.com/djmitche/pynsca/issues/12#issuecomment-60086643"""
+        return text.replace('\\', r'\\').replace('\n', r'\n')
 
     def _force_str(self, text):
         if isinstance(text, unicode):

--- a/test_pynsca.py
+++ b/test_pynsca.py
@@ -313,6 +313,11 @@ class TestPacketMethods(unittest.TestCase):
 
         self.assertEqual(str, type(result))
 
+    def test_escape_newlines(self):
+        self.assertEqual(
+                self.notif._escape_newlines('abc\a\t\n\\'),
+                'abc\a\t\\n\\\\')
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It seems that something in the xoring is off because this simple multiline : 
notif.svc_result(SERVER,"Data cleanup", pynsca.CRITICAL, 'test 1\n\ntest2')
gets logged as:
nsca[23423]: SERVICE CHECK -> Host Name: 'SERVER', Service Description: 'Data cleanup', Return Code: '2', Output: 'test 1#012#012test2' 
and does not render, 
whereas a command line like : 
echo -e 'SERVER\tData cleanup\t3\toutput line1\noutput line 2' |/usr/local/nagios/bin/send_nsca  -H localhost -c etc/send_nsca.cfg 
logs like : 
nsca[9150]: SERVICE CHECK -> Host Name: 'SERVER', Service Description: 'Data cleanup', Return Code: '3', Output
: 'output line1\noutput line 2'
and renders fine.
It seems that no special character goes through. Tested were \n, \t, \r
