### PR TITLE
Update python-pynsca.spec

### DIFF
--- a/python-pynsca.spec
+++ b/python-pynsca.spec
@@ -46,5 +46,5 @@ rm -rf %{buildroot}
 
 %changelog
 
-* Wed Feb 20 2014 Xavier Devlamynck <xd@eyepea.eu> - 1.5-1
+* Thu Feb 20 2014 Xavier Devlamynck <xd@eyepea.eu> - 1.5-1
 - Initial release


### PR DESCRIPTION
corrected date. Just a little thing. The old date Wed Feb 20 2014 was bogus, which lets rpmbuild on some distributions (at least Suse style) fail. 
